### PR TITLE
upgraded virtus to v2

### DIFF
--- a/fake_sns.gemspec
+++ b/fake_sns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sinatra", "~> 1.4"
-  spec.add_dependency "virtus", "~> 1.0"
+  spec.add_dependency "virtus", "~> 2.0"
   spec.add_dependency "verbose_hash_fetch"
   spec.add_dependency "faraday", "~> 0.8"
   spec.add_dependency 'aws-sdk', '~> 2.0'


### PR DESCRIPTION
Upgrades `virtus` gem to v2 for compatibility in the rails-teespring repo